### PR TITLE
Ci caching

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,18 +15,8 @@ jobs:
     steps:
       - uses: actions/checkout@v1
 
-      - name: Cache Python Dependencies
-        id: cache-pip
-        uses: actions/cache@v1
-        with:
-          path: pip-cache
-          key: ${{ runner.os }}-cache-pip
-
       - name: Build Docker Image
-        run: |
-          docker --version
-          docker build -f Dockerfile -t python-representer .
-          find .
+        run: docker build -f Dockerfile -t python-representer .
           
       - name: Run Tests
         run: docker run --entrypoint "pytest" python-representer

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,8 +15,16 @@ jobs:
     steps:
       - uses: actions/checkout@v1
 
+      - name: Cache Python Dependencies
+        id: cache-pip
+        uses: actions/cache@v1
+        with:
+          path: pip-cache
+          key: ${{ runner.os }}-cache-pip
+
       - name: Build Docker Image
         run: |
+          docker --version
           docker build -f Dockerfile -t python-representer .
           find .
           

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,21 @@
-FROM python:3.8-alpine
+FROM python:3.8-alpine as base
+
+FROM base as builder
 
 RUN apk add --no-cache gcc libc-dev unixodbc-dev
+RUN mkdir /install
+WORKDIR /install
 
-COPY *requirements.txt /opt/representer/
-WORKDIR /opt/representer
+COPY requirements.txt /requirements.txt
+COPY dev-requirements.txt /dev-requirements.txt
 
-RUN pip install -r requirements.txt -r dev-requirements.txt
+RUN pip install --install-option="--prefix=/install" -r /requirements.txt -r /dev-requirements.txt
 
+FROM base
+
+COPY --from=builder /install /usr/local
 COPY . /opt/representer
 
-ENTRYPOINT ["sh", "/opt/representer/bin/generate.sh"]
+WORKDIR /opt/representer
+
+ENTRYPOINT ["sh", "bin/generate.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /install
 COPY requirements.txt /requirements.txt
 COPY dev-requirements.txt /dev-requirements.txt
 
-RUN pip install --install-option="--prefix=/install" -r /requirements.txt -r /dev-requirements.txt
+RUN pip install --prefix=/install -r /requirements.txt -r /dev-requirements.txt
 
 FROM base
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /install
 COPY requirements.txt /requirements.txt
 COPY dev-requirements.txt /dev-requirements.txt
 
-RUN pip install --prefix=/install -r /requirements.txt -r /dev-requirements.txt
+RUN pip install --prefix=/install --no-warn-script-location -r /requirements.txt -r /dev-requirements.txt
 
 FROM base
 


### PR DESCRIPTION
More attempts at caching build layers / pip dependencies. Apparently Docker build layers used to work before GA transitioned to yaml-based configuration ... currently the cache Action has no means of accessing the Docker layer cache, so we're basically SOL there.

Newer versions of Docker itself do add features under the umbrella term BuildKIt that could be useful here, as they allow the `docker build` command to mount a cache directory on the host, however the UCP edition of Docker that's installed on the workers doesn't support this yet.

So after even _more_ investigation we're back at no caching ... however I've enabled multi-stage builds, which will make it easier for us to cache intermediate images if we do get an Exercism Docker repo, and _should_ at least in theory keep the final image a little leaner.