### PR TITLE
Use python3.8-slim as base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-slim as base
+FROM python:3.8-slim as base
 
 FROM base as builder
 


### PR DESCRIPTION
The representer tests require features that are not present in 3.7 or older