### PR TITLE
Exercise retrieval updates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,2 @@
-* @cmccandless
-* @bethanyg
+* @cmccandless @bethanyg
 .github/CODEOWNERS @exercism/maintainers-admin

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,3 @@
-* @exercism/maintainers-admin
+* @cmccandless
+* @bethanyg
+.github/CODEOWNERS @exercism/maintainers-admin

--- a/representer/__init__.py
+++ b/representer/__init__.py
@@ -75,9 +75,7 @@ def represent(slug: utils.Slug, input: utils.Directory, output: utils.Directory)
     else:
         src = f'{input.joinpath(slug.replace("-", "_"))}.py'
 
-        try:
-            src.read_text()
-        except AttributeError as err:
+        if not src.is_file():
             print('No exercise file was found in the input directory.', err)
             return
 

--- a/representer/__init__.py
+++ b/representer/__init__.py
@@ -1,7 +1,9 @@
 """
 Representer for Python.
 """
+import json
 from typing import Dict
+
 
 from . import utils
 from .normalizer import Normalizer
@@ -55,10 +57,34 @@ def represent(slug: utils.Slug, input: utils.Directory, output: utils.Directory)
     """
     Normalize the `directory/slug.py` file representation.
     """
-    src = input.joinpath(slug.replace("-", "_") + ".py")
+
+    # get exercise name from config file or compose it from the passed-in slug
+    config_file = input.joinpath(".meta").joinpath("config.json")
+    src = None
+
+    if config_file.is_file():
+        editor_config = json.loads(config_file.read_text())\
+            .get("editor", {})\
+            .get("solution_files", [])
+
+        if editor_config:
+            src = input.joinpath(editor_config[0])
+        else:
+            raise FileNotFoundError("No exercise file was found in config.json.")
+
+    else:
+        src = f'{input.joinpath(slug.replace("-", "_"))}.py'
+
+        try:
+            src.read_text()
+        except AttributeError as err:
+            print('No exercise file was found in the input directory.', err)
+            return
+
     out_dst = output.joinpath("representation.out")
     txt_dst = output.joinpath("representation.txt")
     map_dst = output.joinpath("mapping.json")
+
 
     # parse the tree from the file contents
     representation = Representer(src.read_text())

--- a/representer/utils.py
+++ b/representer/utils.py
@@ -17,7 +17,7 @@ import black
 
 Slug = NewType("Slug", str)
 
-SLUG_RE = re.compile(r"^[a-z]+(-[a-z]+)*$")
+SLUG_RE = re.compile(r"^[a-z]+([-_][a-z]+)*$")
 
 
 def slug(string: str) -> Slug:

--- a/representer/utils.py
+++ b/representer/utils.py
@@ -17,7 +17,7 @@ import black
 
 Slug = NewType("Slug", str)
 
-SLUG_RE = re.compile(r"^[a-z]+([-_][a-z]+)*$")
+SLUG_RE = re.compile(r"^[a-z]+(-[a-z]+)*$")
 
 
 def slug(string: str) -> Slug:


### PR DESCRIPTION
- Added code and some error handling for retrieving the exercise file name from either `config.json` or via the passed-in slug name.
- Changed the SLUG_RE code to accept an underscore as part of a valid slug name

Decided to not change the code to accept more than one exercise file since we don't currently have any mulit-file exercises in either the concept nor practice categories.