### PR TITLE
Make representer ignore type annotations in more places

### DIFF
--- a/representer/normalizer.py
+++ b/representer/normalizer.py
@@ -5,7 +5,9 @@ import builtins
 from itertools import count
 from typing import Dict, Optional, overload
 from ast import (
+    AnnAssign,
     AST,
+    Assign,
     AsyncFunctionDef,
     Attribute,
     ClassDef,
@@ -113,7 +115,21 @@ class Normalizer(NodeTransformer):
         """
         Any `def name` definition.
         """
+        if node.returns:
+            node.returns = None
         return self._visit_definition(node)
+
+    def visit_AnnAssign(self, node: AnnAssign) -> Assign:
+        """
+        Any type-annotated assignment
+
+        Converts type-annotated assignments to regular assignments.
+        """
+        new_assign = Assign(targets=[node.target],
+                            value=node.value,
+                            lineno=node.lineno)
+        self.generic_visit(new_assign)
+        return new_assign
 
     def visit_AsyncFunctionDef(self, node: AsyncFunctionDef) -> AsyncFunctionDef:
         """

--- a/test/test_representer.py
+++ b/test/test_representer.py
@@ -303,6 +303,30 @@ class RepresenterNormalizationTest(unittest.TestCase):
                 """
         self.assertCodeEqual(before, expect)
 
+    def test_def_functions_with_annotations_in_signature(self):
+        before = """\
+                def func(a: int, b: int) -> int:
+                    return a + b
+                """
+        expect = """\
+                def placeholder_0(placeholder_1, placeholder_2):
+                    return placeholder_1 + placeholder_2
+                """
+        self.assertCodeEqual(before, expect)
+
+    def test_def_functions_with_annotations_in_body(self):
+        before = """\
+                def func(a: int, b: int) -> int:
+                    c: int = 2
+                    return a + b + c
+                """
+        expect = """\
+                def placeholder_0(placeholder_1, placeholder_2):
+                    placeholder_3 = 2
+                    return placeholder_1 + placeholder_2 + placeholder_3
+                """
+        self.assertCodeEqual(before, expect)
+
     def test_async_def_functions(self):
         before = """\
                 async def afunc(posarg, defarg=None, *varargs, **nameargs):


### PR DESCRIPTION
Currently, the representer is ignoring type annotations from function arguments, but not from the return type of functions and from type-annotated variables.

This PR makes the representer ignore type annotations from those places too.